### PR TITLE
Support for new AWS URL patterns

### DIFF
--- a/src/main/helpers/markdown.test.ts
+++ b/src/main/helpers/markdown.test.ts
@@ -3,22 +3,18 @@ import { convertS3ImageUrl } from "./markdown";
 
 beforeAll(async () => {
   await saveImageMap(
-    s3url,
+    "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject",
     "static/pimages/page-object-id/abcdefgh-1234-5678-abcd-123456789012-Untitled.png"
+  );
+  await saveImageMap(
+    "https://prod-files-secure.s3.us-west-2.amazonaws.com/01010101-0101-4070-0101-478b36d11111/01010101-0101-0101-0101-101010101010/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT7",
+    "static/pimages/page-object-id/01010101-0101-4070-0101-478b36d11111-01010101-0101-0101-0101-101010101010-Untitled.png"
   );
 });
 
 describe("convertS3ImageUrl", () => {
-  test("Matchs the AWS url", async () => {
-    const result = await convertS3ImageUrl(md_one);
-    expect(result).toBe(md_one_expected);
-  });
-});
-
-const s3url =
-  "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject";
-
-const md_one = `
+  test("Matches the AWS url", async () => {
+    const md_one = `
 # Hello notion with s3 image
 
 ![](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject)
@@ -28,7 +24,7 @@ const md_one = `
 end of md
 `;
 
-const md_one_expected = `
+    const md_one_expected = `
 # Hello notion with s3 image
 
 ![](/pimages/page-object-id/abcdefgh-1234-5678-abcd-123456789012-Untitled.png)
@@ -37,3 +33,30 @@ const md_one_expected = `
 
 end of md
 `;
+
+    const result = await convertS3ImageUrl(md_one);
+    expect(result).toBe(md_one_expected);
+  });
+
+  // 新たなS3 URLのテストパターン
+  test("Matches the new AWS url pattern", async () => {
+    const md_two = `
+# Test with new S3 image
+
+![](https://prod-files-secure.s3.us-west-2.amazonaws.com/01010101-0101-4070-0101-478b36d11111/01010101-0101-0101-0101-101010101010/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT7)
+
+end of md
+`;
+
+    const md_two_expected = `
+# Test with new S3 image
+
+![](/pimages/page-object-id/01010101-0101-4070-0101-478b36d11111-01010101-0101-0101-0101-101010101010-Untitled.png)
+
+end of md
+`;
+
+    const result = await convertS3ImageUrl(md_two);
+    expect(result).toBe(md_two_expected);
+  });
+});

--- a/src/main/helpers/markdown.test.ts
+++ b/src/main/helpers/markdown.test.ts
@@ -1,29 +1,39 @@
 import { saveImageMap } from "./donwload";
 import { convertS3ImageUrl } from "./markdown";
 
+// Sample AWS S3 URLs for testing
+const awsUrlPattern_1 =
+  "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject";
+
+const awsUrlPattern_2 =
+  "https://prod-files-secure.s3.us-west-2.amazonaws.com/01010101-0101-4070-0101-478b36d11111/01010101-0101-0101-0101-101010101010/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT7";
+
+// Save image mappings before running tests
 beforeAll(async () => {
   await saveImageMap(
-    "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject",
+    awsUrlPattern_1,
     "static/pimages/page-object-id/abcdefgh-1234-5678-abcd-123456789012-Untitled.png"
   );
   await saveImageMap(
-    "https://prod-files-secure.s3.us-west-2.amazonaws.com/01010101-0101-4070-0101-478b36d11111/01010101-0101-0101-0101-101010101010/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT7",
+    awsUrlPattern_2,
     "static/pimages/page-object-id/01010101-0101-4070-0101-478b36d11111-01010101-0101-0101-0101-101010101010-Untitled.png"
   );
 });
 
 describe("convertS3ImageUrl", () => {
   test("Matches the AWS url", async () => {
+    // Markdown content with the first AWS S3 URL
     const md_one = `
 # Hello notion with s3 image
 
-![](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject)
+![](${awsUrlPattern_1})
 
-![Image Title](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject)
+![Image Title](${awsUrlPattern_1})
 
 end of md
 `;
 
+    // Expected markdown content after URL conversion
     const md_one_expected = `
 # Hello notion with s3 image
 
@@ -34,20 +44,23 @@ end of md
 end of md
 `;
 
+    // Convert S3 URLs in the markdown content
     const result = await convertS3ImageUrl(md_one);
+    // Check if the result matches the expected content
     expect(result).toBe(md_one_expected);
   });
 
-  // 新たなS3 URLのテストパターン
   test("Matches the new AWS url pattern", async () => {
+    // Markdown content with the second AWS S3 URL
     const md_two = `
 # Test with new S3 image
 
-![](https://prod-files-secure.s3.us-west-2.amazonaws.com/01010101-0101-4070-0101-478b36d11111/01010101-0101-0101-0101-101010101010/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT7)
+![](${awsUrlPattern_2})
 
 end of md
 `;
 
+    // Expected markdown content after URL conversion
     const md_two_expected = `
 # Test with new S3 image
 
@@ -56,7 +69,9 @@ end of md
 end of md
 `;
 
+    // Convert S3 URLs in the markdown content
     const result = await convertS3ImageUrl(md_two);
+    // Check if the result matches the expected content
     expect(result).toBe(md_two_expected);
   });
 });

--- a/src/main/helpers/notionImage.test.ts
+++ b/src/main/helpers/notionImage.test.ts
@@ -8,10 +8,17 @@ import {
 
 const s3DummyUrl =
   "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=CREDENTIALCREDENTIALCREDENTIAL0%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220101T000000Z&X-Amz-Expires=3600&X-Amz-Signature=signaturedummyasignaturedummyasignaturedummyasignaturedummyadef3&X-Amz-SignedHeaders=host&x-id=GetObject";
+const s3urlPatternProdFiles =
+  "https://prod-files-secure.s3.us-west-2.amazonaws.com/76a0cc38-9fd7-4070-92db-478b36d526b2/d899991c-2faf-4f57-b7c0-4c76f3156c25/Untitled.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2";
 
 describe("isAwsImageUrl", () => {
   test("Matchs the AWS url", () => {
     const result = isAwsImageUrl(s3DummyUrl);
+    expect(result).toBe(true);
+  });
+
+  test("Matchs the AWS url", () => {
+    const result = isAwsImageUrl(s3urlPatternProdFiles);
     expect(result).toBe(true);
   });
 
@@ -25,6 +32,11 @@ describe("isAwsImageUrl", () => {
 describe("isAwsImageUrlString", () => {
   test("Matchs the AWS url", () => {
     const result = isAwsImageUrlString(s3DummyUrl);
+    expect(result).toBe(true);
+  });
+
+  test("Matchs the AWS url", () => {
+    const result = isAwsImageUrlString(s3urlPatternProdFiles);
     expect(result).toBe(true);
   });
 
@@ -58,6 +70,13 @@ describe("getImageFullName", () => {
     const result = getImageFullName(s3DummyUrl);
     expect(result).toEqual(
       "secure.notion-static.com/abcdefgh-1234-5678-abcd-123456789012/Untitled.png"
+    );
+  });
+
+  test("Matchs full filename", () => {
+    const result = getImageFullName(s3urlPatternProdFiles);
+    expect(result).toEqual(
+      "76a0cc38-9fd7-4070-92db-478b36d526b2/d899991c-2faf-4f57-b7c0-4c76f3156c25/Untitled.png"
     );
   });
 

--- a/src/main/helpers/validation.ts
+++ b/src/main/helpers/validation.ts
@@ -1,6 +1,6 @@
 export const includeAwsImageUrl = (markdownText: string): boolean => {
   const s3pattern = new RegExp(
-    /https:\/\/s3.+amazonaws\.com.+X-Amz-Credential.+/,
+    /https:\/\/(?:s3|prod-files-secure\.s3)\.[^/]+\.amazonaws\.com.+X-Amz-Credential.+/,
     "gm"
   );
 


### PR DESCRIPTION
Fixed an issue where Markdown rewrites did not work when the S3 hostname had been changed

Before:
`https://s3.us-west-2.amazonaws.com/secure.notion-static.com ...`

After:
`https://prod-files-secure.s3.us-west-2.amazonaws.com/ ...`

## Note
Note: I assume that the new host alone will be able to handle it, but I have not checked all the operation cases, so I will leave the old and new URL patterns.